### PR TITLE
Allow more options to be configured in the config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ s3cmd::config {'root':
 }
 ```
 
+###Create multiple .s3cfg files with hiera
+
+```yaml
+--
+s3cmd::config:
+  root:
+    aws_access_key: 'AUIAJYSJQT5WQ5S7EISQ'
+    aws_secret_key: 'Kd24SfkdcQfsS4294MSKAS432'
+  root_other:
+    aws_access_key: 'AUIAJYSJQT5WQ5S7EISQ'
+    aws_secret_key: 'Kd24SfkdcQfsS4294MSKAS432'
+    user: 'root'
+    filename: '.s3cmd-other'
+```
+
+And simply include s3cmd module:
+
+```puppet
+include '::s3cmd'
+```
+
+
 ###Parameters
 
 ####s3cmd
@@ -52,12 +74,26 @@ Valid value present/absent
 Remove or install the s3cmd config file. Possible values present or absent
 `Default: present`
 
-#####`bucket_location` 
+#####`filename`
 
-AWS S3 supports the following buckets: 
-US, EU or eu-west-1, us-west-1 (Oregon),  us-west-1 (N California), 
-ap-southeast-1 (Singapore), ap-southeast-2 (Sydney), ap-northeast-1 (Tokyo) 
+The filename of the deployed config. *Default: .s3cfg*
+
+#####`bucket_location`
+
+AWS S3 supports the following buckets:
+US, EU or eu-west-1, us-west-1 (Oregon),  us-west-1 (N California),
+ap-southeast-1 (Singapore), ap-southeast-2 (Sydney), ap-northeast-1 (Tokyo)
 and sa-east-1 (Sao Paulo). *Default: US*
+
+#####`host_base`
+
+The base host to use. You'll want to change this if using a different
+bucket_location. *Default: s3.amazonaws.com*
+
+#####`host_bucket`
+
+The hostname that resolves to your bucket. You'll want to change this if
+using a different bucket_location. *Default: %(bucket)s.s3.amazonaws.com*
 
 #####`use_https`
 
@@ -67,6 +103,10 @@ If use HTTPS protocol for communication with Amazon S3. *Default: True*
 
 Encryption password is used to protect your files from reading
 by unauthorized persons while in transfer to S3. *Default: undef*
+
+#####`encrypt`
+
+Client side encryption. *Default: false*
 
 #####`user`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,11 +14,22 @@
 # [*aws_secret_key*]
 #   AWS secret key
 #
+# [*filename*]
+#   The filename of the deployed config. Default: .s3cfg
+#
 # [*bucket_location*]
 #   default bucket location is US. As for now AWS/s3md supports the
-#   following buckets: US, EU or eu-west-1, us-west-1 (Oregon), 
-#   us-west-1 (Northern California), ap-southeast-1 (Singapore), 
+#   following buckets: US, EU or eu-west-1, us-west-1 (Oregon),
+#   us-west-1 (Northern California), ap-southeast-1 (Singapore),
 #    ap-southeast-2 (Sydney), ap-northeast-1 (Tokyo) and sa-east-1 (Sao Paulo)
+#
+# [*host_base*]
+#   The base host to use. You'll want to change this if using a different
+#   bucket_location. Default: s3.amazonaws.com
+#
+# [*host_bucket*]
+#   The hostname that resolves to your bucket. You'll want to change this if
+#   using a different bucket_location. Default: %(bucket)s.s3.amazonaws.com
 #
 # [*use_https*]
 #   If use HTTPS protocol for communication with Amazon S3
@@ -27,14 +38,17 @@
 #   Encryption password is used to protect your files from reading
 #   by unauthorized persons while in transfer to S3
 #
+# [*encrypt*]
+#   Client side encryption. Default: false
+#
 # [*user*]
 #   system username which defines the .s3cfg file location.
 #
 # [*path_to_gpg*]
-#   Path to GPG program needed for encryption 
+#   Path to GPG program needed for encryption
 #
 # [*home_dir*]
-#   overwrites the default home dir of the user in case you are not 
+#   overwrites the default home dir of the user in case you are not
 #   using /home or /root for root
 #
 # === Examples
@@ -54,9 +68,13 @@ define s3cmd::config(
   $aws_access_key,
   $aws_secret_key,
   $ensure                = 'present',
+  $filename              = '.s3cfg',
   $user                  = $title,
   $bucket_location       = 'US',
+  $host_base             = 's3.amazonaws.com',
+  $host_bucket           = '%(bucket)s.s3.amazonaws.com',
   $use_https             = true,
+  $encrypt               = false,
   $encryption_passphrase = undef,
   $path_to_gpg           = '/usr/bin/gpg',
   $proxy_host            = undef,
@@ -78,7 +96,7 @@ define s3cmd::config(
     }
   }
 
-  file { "${home_path}/.s3cfg":
+  file { "${home_path}/${filename}":
     ensure  => $ensure,
     content => template('s3cmd/s3cfg.erb'),
     owner   => $user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,4 +39,7 @@ class s3cmd(
     ensure => $ensure,
     name   => $s3cmd::params::package_name,
   }
+
+  # auto-create configs from hiera
+  create_resources('s3cmd::config', hiera_hash('s3cmd::config', {}))
 }

--- a/templates/s3cfg.erb
+++ b/templates/s3cfg.erb
@@ -20,7 +20,7 @@ gpg_encrypt = %(gpg_command)s -c --verbose --no-use-agent --batch --yes --passph
 <% else -%>
 gpg_passphrase =
 <% end -%>
-guess_mime_type = True
+guess_mime_type = False
 host_base = <%= @host_base %>
 host_bucket = <%= @host_bucket %>
 human_readable_sizes = False

--- a/templates/s3cfg.erb
+++ b/templates/s3cfg.erb
@@ -7,7 +7,9 @@ default_mime_type = binary/octet-stream
 delete_removed = False
 dry_run = False
 encoding = UTF-8
-encrypt = False
+<% if @encrypt == true -%>encrypt = True
+<% else -%>encrypt = False
+<% end -%>
 follow_symlinks = False
 force = False
 get_continue = False
@@ -19,11 +21,11 @@ gpg_encrypt = %(gpg_command)s -c --verbose --no-use-agent --batch --yes --passph
 gpg_passphrase =
 <% end -%>
 guess_mime_type = True
-host_base = s3.amazonaws.com
-host_bucket = %(bucket)s.s3.amazonaws.com
+host_base = <%= @host_base %>
+host_bucket = <%= @host_bucket %>
 human_readable_sizes = False
 list_md5 = False
-log_target_prefix = 
+log_target_prefix =
 preserve_attrs = True
 progress_meter = True
 proxy_host = <%= @proxy_host %>


### PR DESCRIPTION
Several options like `host_base` and `host_bucket` usually need to change when the `bucket_location` is overridden. I've also allowed `encrypt` to be configured.

Configuring the `filename` is required where a user may have multiple config files that they use with the `s3cmd -c` switch.

I've also allowed s3cfg files to be created purely with hiera by auto-loading anything under the `s3cmd::config` hash. I find this is really convenient for the majority of cases that just want to define a couple of access keys in hiera and move on, without having to change any puppet code for the next change.
